### PR TITLE
updated Mp3MediaStreamSource

### DIFF
--- a/MediaParsers/BitTools.cs
+++ b/MediaParsers/BitTools.cs
@@ -7,7 +7,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Rdio.Player.StreamSource
+namespace MediaParsers
 {
     using System;
     using System.Diagnostics;

--- a/MediaParsers/BitTools.cs
+++ b/MediaParsers/BitTools.cs
@@ -7,10 +7,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace MediaParsers
+namespace Rdio.Player.StreamSource
 {
     using System;
     using System.Diagnostics;
+    using System.Text;
 
     /// <summary>
     /// Helper methods for manipulating values at the byte and binary level.
@@ -330,6 +331,16 @@ namespace MediaParsers
         public static int FindBytePattern(byte[] data, byte[] pattern)
         {
             return FindBytePattern(data, pattern, 0);
+        }
+
+        public static string ToLittleEndianString(string bigEndianString)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            for (int i = 0; i < bigEndianString.Length; i += 2)
+                builder.Insert(0, bigEndianString.Substring(i, 2));
+
+            return builder.ToString();
         }
     }
 }

--- a/MediaParsers/MpegFrame.cs
+++ b/MediaParsers/MpegFrame.cs
@@ -11,17 +11,17 @@
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional",
     Scope = "member",
-    Target = "MediaParsers.MpegFrame.#bitrateTable",
+    Target = "Rdio.Player.StreamSource.MpegFrame.#bitrateTable",
     MessageId = "Member",
     Justification = "Array is not Jagged and does not waste space.")]
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional",
     Scope = "member",
-    Target = "MediaParsers.MpegFrame.#samplingRateTable",
+    Target = "Rdio.Player.StreamSource.MpegFrame.#samplingRateTable",
     MessageId = "Member",
     Justification = "Array is not Jagged and does not waste space.")]
 
-namespace MediaParsers
+namespace Rdio.Player.StreamSource
 {
     using System;
     using System.IO;
@@ -84,7 +84,7 @@ namespace MediaParsers
         /// <summary>
         /// MP3 Headers are 4 Bytes long
         /// </summary>
-        private const int FrameHeaderSize = 4;
+        public const int FrameHeaderSize = 4;
         
         /// <summary>
         /// A table of bitrates / 1000. These are all of the possible bitrates for Mpeg 1 - 2.5 audio. -1 encodes an error lookup.
@@ -109,6 +109,11 @@ namespace MediaParsers
             };
 
         /// <summary>
+        /// The frame header for this frame describing its contents. 
+        /// </summary>
+        private byte[] frameHeader;
+
+        /// <summary>
         /// Initializes a new instance of the MpegFrame class.
         /// </summary>
         /// <param name="stream">
@@ -116,8 +121,8 @@ namespace MediaParsers
         /// </param>
         public MpegFrame(Stream stream)
         {
-            long startPostion = stream.Position;
-            byte[] frameHeader = new byte[FrameHeaderSize];
+            //long startPostion = stream.Position;
+            frameHeader = new byte[FrameHeaderSize];
 
             // Guard against a read error
             if (stream.Read(frameHeader, 0, FrameHeaderSize) != FrameHeaderSize)
@@ -147,7 +152,7 @@ namespace MediaParsers
 
             return;
         cleanup:
-            stream.Position = startPostion;
+            //stream.Position = startPostion;
             frameHeader = null;
             return;
         }
@@ -393,6 +398,11 @@ namespace MediaParsers
             }
 
             return channel;
+        }
+
+        public void CopyHeader(byte[] destinationBuffer, int offset)
+        {
+            frameHeader.CopyTo(destinationBuffer, offset);
         }
     }
 }

--- a/MediaParsers/MpegFrame.cs
+++ b/MediaParsers/MpegFrame.cs
@@ -11,17 +11,17 @@
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional",
     Scope = "member",
-    Target = "Rdio.Player.StreamSource.MpegFrame.#bitrateTable",
+    Target = "MediaParsers.MpegFrame.#bitrateTable",
     MessageId = "Member",
     Justification = "Array is not Jagged and does not waste space.")]
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1814:PreferJaggedArraysOverMultidimensional",
     Scope = "member",
-    Target = "Rdio.Player.StreamSource.MpegFrame.#samplingRateTable",
+    Target = "MediaParsers.MpegFrame.#samplingRateTable",
     MessageId = "Member",
     Justification = "Array is not Jagged and does not waste space.")]
 
-namespace Rdio.Player.StreamSource
+namespace MediaParsers
 {
     using System;
     using System.IO;
@@ -121,7 +121,6 @@ namespace Rdio.Player.StreamSource
         /// </param>
         public MpegFrame(Stream stream)
         {
-            //long startPostion = stream.Position;
             frameHeader = new byte[FrameHeaderSize];
 
             // Guard against a read error
@@ -152,7 +151,6 @@ namespace Rdio.Player.StreamSource
 
             return;
         cleanup:
-            //stream.Position = startPostion;
             frameHeader = null;
             return;
         }

--- a/MediaParsers/MpegLayer3WaveFormat.cs
+++ b/MediaParsers/MpegLayer3WaveFormat.cs
@@ -7,11 +7,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace MediaParsers
+namespace Rdio.Player.StreamSource
 {
     using System;
     using System.Globalization;
-    using ExtensionMethods;
+    using System.Text;
     
     /// <summary>
     /// A managed representation of the multimedia MPEGLAYER3WAVEFORMATEX 
@@ -87,11 +87,11 @@ namespace MediaParsers
         public string ToHexString()
         {
             string s = WaveFormatExtensible.ToHexString();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Id).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.BitratePaddingMode).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BlockSize).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.FramesPerBlock).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.CodecDelay).ToLittleEndian();
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Id));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.BitratePaddingMode));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BlockSize));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.FramesPerBlock));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.CodecDelay));
             return s;
         }
 

--- a/MediaParsers/MpegLayer3WaveFormat.cs
+++ b/MediaParsers/MpegLayer3WaveFormat.cs
@@ -7,7 +7,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Rdio.Player.StreamSource
+namespace MediaParsers
 {
     using System;
     using System.Globalization;

--- a/MediaParsers/StringExtensions.cs
+++ b/MediaParsers/StringExtensions.cs
@@ -7,18 +7,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-// Supressing Code Analysis rule(s)
-[module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1020:AvoidNamespacesWithFewTypes",
-    Scope = "namespace",
-    Target = "ExtensionMethods",
-    Justification = "This is appropriate as a separate namespace because it logically is separate from the ManagedMediaParsers namespace.")]
-
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes",
     Scope = "member",
-    Target = "ExtensionMethods.StringExtensions.#ToLittleEndian(System.String)",
+    Target = "Rdio.Player.StreamSource.StringExtensions.#ToLittleEndian(System.String)",
     Justification = "This is appropriate to make this method look like a first class member of string.")]
 
-namespace ExtensionMethods
+namespace Rdio.Player.StreamSource
 {
     using System;
 

--- a/MediaParsers/StringExtensions.cs
+++ b/MediaParsers/StringExtensions.cs
@@ -9,10 +9,10 @@
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes",
     Scope = "member",
-    Target = "Rdio.Player.StreamSource.StringExtensions.#ToLittleEndian(System.String)",
+    Target = "ExtensionMethods.StringExtensions.#ToLittleEndian(System.String)",
     Justification = "This is appropriate to make this method look like a first class member of string.")]
 
-namespace Rdio.Player.StreamSource
+namespace ExtensionMethods
 {
     using System;
 

--- a/MediaParsers/WaveFormatExtensible.cs
+++ b/MediaParsers/WaveFormatExtensible.cs
@@ -7,7 +7,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Rdio.Player.StreamSource
+namespace MediaParsers
 {
     using System;
     using System.Globalization;

--- a/MediaParsers/WaveFormatExtensible.cs
+++ b/MediaParsers/WaveFormatExtensible.cs
@@ -7,11 +7,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace MediaParsers
+namespace Rdio.Player.StreamSource
 {
     using System;
     using System.Globalization;
-    using ExtensionMethods;
     
     /// <summary>
     /// A managed representation of the multimedia WAVEFORMATEX structure
@@ -88,13 +87,13 @@ namespace MediaParsers
         /// </returns>
         public string ToHexString()
         {
-            string s = string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.FormatTag).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Channels).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.SamplesPerSec).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.AverageBytesPerSecond).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BlockAlign).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BitsPerSample).ToLittleEndian();
-            s += string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Size).ToLittleEndian();
+            string s = BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.FormatTag));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Channels));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.SamplesPerSec));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X8}", this.AverageBytesPerSecond));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BlockAlign));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.BitsPerSample));
+            s += BitTools.ToLittleEndianString(string.Format(CultureInfo.InvariantCulture, "{0:X4}", this.Size));
             return s;
         }
 

--- a/Mp3MediaStreamSource/Mp3MediaStreamSource.cs
+++ b/Mp3MediaStreamSource/Mp3MediaStreamSource.cs
@@ -14,7 +14,7 @@
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming",
     "CA1709:IdentifiersShouldBeCasedCorrectly",
     Scope = "type",
-    Target = "Rdio.Player.StreamSource.Mp3MediaStreamSource",
+    Target = "Media.Mp3MediaStreamSource",
     MessageId = "Mp",
     Justification = "Mp is not a two letter acyonym but is instead part of Mp3")]
 
@@ -22,16 +22,13 @@
  * Presents a byte stream as mp3 frames for the Media Element.  
  * Based on ManagedMediaHelpers code sample from http://code.msdn.microsoft.com/ManagedMediaHelpers/
  * 
- * Tweaked to work on WinPho. Changes include BitTools.ToLittleEndianString and setting the duration properly based
- * on bit rate & content length.  Also added support for non-seekable content and to be more memory-efficient
+ * Tweaked to work on WinPho. Changes include BitTools.ToLittleEndianString
+ * and setting the duration properly based on bit rate & content length.
+ * Also added support for non-seekable content and to be more memory-efficient
  * to avoid copying the entire audio stream's data into memory.
- * 
- * NOTE:
- *   - Does not support seeking yet
- *   - Needs some extra buffering logic
  */
 
-namespace Rdio.Player.StreamSource
+namespace Media
 {
     using System;
     using System.Collections.Generic;
@@ -40,7 +37,6 @@ namespace Rdio.Player.StreamSource
     using System.Windows.Media;
     using System.Windows.Threading;
     using System.Diagnostics;
-    using Rdio.Util;
     using System.Security.Cryptography;
 
     /// <summary>
@@ -49,8 +45,6 @@ namespace Rdio.Player.StreamSource
     /// </summary>
     public class Mp3MediaStreamSource : MediaStreamSource
     {
-        private const String TAG = "Mp3MediaStreamSource";
-
         /// <summary>
         ///  ID3 version 1 tags are 128 bytes at the end of the file.
         ///  http://www.id3.org/ID3v1
@@ -209,7 +203,7 @@ namespace Rdio.Player.StreamSource
                 int c = this.audioStream.Read(buffer, MpegFrame.FrameHeaderSize, audioSampleSize);
                 if (c != audioSampleSize)
                 {
-                    Log.Error(TAG, "Ran out of bytes trying to read MP3 frame.  Audio sample size was: " + audioSampleSize + ", actual bytes read: " + c);
+                    // Ran out of bytes trying to read MP3 frame.
                     this.currentFrame = null;
                     audioSample = new MediaStreamSample(this.audioStreamDescription, null, 0, 0, 0, emptyDict);
                     this.ReportGetSampleCompleted(audioSample);
@@ -254,11 +248,13 @@ namespace Rdio.Player.StreamSource
             }
             catch (CryptographicException)
             {
-                // Ignore these, they are thrown when abruptly closing a stream (i.e. skipping tracks)
+                // Ignore these, they are thrown when abruptly closing a
+                // stream (i.e. skipping tracks) where the source is a
+                // CryptoStream
             }
             catch (Exception e)
             {
-                Log.Error(TAG, "Got exception closing stream: ", e);
+                // Should probably log these somewhere
             }
         }
 

--- a/Mp3MediaStreamSource/Mp3MediaStreamSource.cs
+++ b/Mp3MediaStreamSource/Mp3MediaStreamSource.cs
@@ -38,6 +38,7 @@ namespace Media
     using System.Windows.Threading;
     using System.Diagnostics;
     using System.Security.Cryptography;
+    using MediaParsers;
 
     /// <summary>
     /// A Simple MediaStreamSource which can play back MP3 streams from


### PR DESCRIPTION
- works on Windows Phone (which requires timestamp to be non-zero)
- should theoretically allow seeking if playing a memorystream (since the timestamp is now actually calculated to be a real value)
- reports positioning properly
- supports non-seekable content (e.g. CryptoStream, NetworkStreams which aren't fully buffered)
- removes the code that reads the whole stream into memory allowing it to read a frame at a time.  should be more memory efficient this way.
